### PR TITLE
fix: -v will not work without boolean value

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,14 +50,14 @@ func run() int {
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.Parse()
 
-	if flag.NArg() == 0 {
-		flag.Usage()
-		os.Exit(2)
-	}
-
 	if showVersion {
 		fmt.Println(version)
 		os.Exit(0)
+	}
+
+	if flag.NArg() == 0 {
+		flag.Usage()
+		os.Exit(2)
 	}
 
 	store, err := leveldb.OpenFile(f, nil)


### PR DESCRIPTION
A simple `-v` command to get version won't work because this is not considered as a Argument by `go/flag` package. 
To make it work we have to use `-v true`. 

To fix this, we can just check for `showVersion` flag before checking the number of arguments. 


![image](https://github.com/mattn/backoff/assets/82411321/586ad663-bf27-4493-a7a9-771d30431014)
